### PR TITLE
Feat: Add article api feature

### DIFF
--- a/src/main/java/com/io/linkapp/config/SwaggerConfig.java
+++ b/src/main/java/com/io/linkapp/config/SwaggerConfig.java
@@ -32,6 +32,7 @@ public class SwaggerConfig {
         
         int tagOrd = 0;
         docket.tags(
+            new Tag("Article", "아티클 API", ++tagOrd),
             new Tag("Tag", "태그 API", ++tagOrd),
             new Tag("Memo", "메모 API", ++tagOrd)
         );

--- a/src/main/java/com/io/linkapp/exception/ArticleException.java
+++ b/src/main/java/com/io/linkapp/exception/ArticleException.java
@@ -1,0 +1,11 @@
+package com.io.linkapp.exception;
+
+public abstract class ArticleException extends RuntimeException{
+
+    public ArticleException(String message) {
+        super(message);
+    }
+
+    public abstract int statusCode();
+
+}

--- a/src/main/java/com/io/linkapp/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/io/linkapp/exception/ArticleNotFoundException.java
@@ -1,0 +1,18 @@
+package com.io.linkapp.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ArticleNotFoundException extends ArticleException{
+
+    private static final String MESSAGE = "존재하지 않는 기사입니다.";
+
+    public ArticleNotFoundException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int statusCode() {
+        return 404;
+    }
+}

--- a/src/main/java/com/io/linkapp/exception/MemoException.java
+++ b/src/main/java/com/io/linkapp/exception/MemoException.java
@@ -1,7 +1,5 @@
 package com.io.linkapp.exception;
 
-import lombok.Getter;
-
 public abstract class MemoException extends RuntimeException{
 
     public MemoException(String message) {

--- a/src/main/java/com/io/linkapp/link/controller/api/ArticleApi.java
+++ b/src/main/java/com/io/linkapp/link/controller/api/ArticleApi.java
@@ -1,21 +1,16 @@
 package com.io.linkapp.link.controller.api;
 
-import com.io.linkapp.link.domain.Article;
 import com.io.linkapp.link.request.ArticleRequest;
 import com.io.linkapp.link.response.ArticleResponse;
 import com.io.linkapp.link.service.ArticleService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 import java.util.List;
 import java.util.UUID;
-import javax.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
 
 @Api(value = "Article", tags = {"Article"})
 @RequiredArgsConstructor

--- a/src/main/java/com/io/linkapp/link/controller/api/ArticleApi.java
+++ b/src/main/java/com/io/linkapp/link/controller/api/ArticleApi.java
@@ -1,0 +1,50 @@
+package com.io.linkapp.link.controller.api;
+
+import com.io.linkapp.link.domain.Article;
+import com.io.linkapp.link.request.ArticleRequest;
+import com.io.linkapp.link.response.ArticleResponse;
+import com.io.linkapp.link.service.ArticleService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import java.util.UUID;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(value = "Article", tags = {"Article"})
+@RequiredArgsConstructor
+@RestController
+public class ArticleApi {
+
+    private final ArticleService articleService;
+
+    @ApiOperation("링크 저장")
+    @PostMapping("/article")
+    public void add(@RequestBody @Valid ArticleRequest articleRequest) {
+        articleService.add(articleRequest);
+    }
+
+    @ApiOperation("링크 전체 조회")
+    @GetMapping("/articles")
+    public List<ArticleResponse> getList() {
+        return articleService.getList();
+    }
+
+    @ApiOperation("링크 조회")
+    @GetMapping("/article/{id}")
+    public ArticleResponse get(@PathVariable("id") UUID uuid) {
+        return articleService.findById(uuid);
+    }
+
+    @ApiOperation("링크 삭제")
+    @DeleteMapping("/article/{id}")
+    public void remove(@PathVariable("id") UUID uuid) {
+        articleService.remove(uuid);
+    }
+}

--- a/src/main/java/com/io/linkapp/link/controller/api/MemoApi.java
+++ b/src/main/java/com/io/linkapp/link/controller/api/MemoApi.java
@@ -1,9 +1,8 @@
 package com.io.linkapp.link.controller.api;
 
-import com.io.linkapp.link.domain.Memo;
-import com.io.linkapp.link.service.MemoService;
 import com.io.linkapp.link.request.MemoRequest;
 import com.io.linkapp.link.response.MemoResponse;
+import com.io.linkapp.link.service.MemoService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
@@ -17,11 +16,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(value = "Memo", tags = {"Memo"})
-@RequestMapping(value = "/api")
 @RequiredArgsConstructor
 @RestController
 public class MemoApi {
@@ -37,8 +34,8 @@ public class MemoApi {
 
     @ApiOperation("메모 전체 조회")
     @GetMapping("/memos")
-    public ResponseEntity<List<Memo>> getList(){
-        List<Memo> memos = memoService.getList();
+    public ResponseEntity<List<MemoResponse>> getList(){
+        List<MemoResponse> memos = memoService.getList();
         return ResponseEntity.ok(memos);
     }
 

--- a/src/main/java/com/io/linkapp/link/domain/Article.java
+++ b/src/main/java/com/io/linkapp/link/domain/Article.java
@@ -1,0 +1,47 @@
+package com.io.linkapp.link.domain;
+
+import com.io.linkapp.common.BaseTimeEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Article extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @Column(name = "article_id")
+    private UUID id;
+    private UUID userId;
+    private UUID folderId;
+    private UUID remindId;
+
+    private String linkTitle;
+    private String linkContent;
+
+    @OneToMany(mappedBy = "article")
+    private List<Memo> memos = new ArrayList<>();
+
+    private boolean isPin;
+    private boolean isMemo;
+
+    @Builder
+    public Article(UUID userId, UUID folderId, UUID remindId, String linkTitle,
+        String linkContent) {
+        this.userId = userId;
+        this.folderId = folderId;
+        this.remindId = remindId;
+        this.linkTitle = linkTitle;
+        this.linkContent = linkContent;
+    }
+}

--- a/src/main/java/com/io/linkapp/link/domain/Article.java
+++ b/src/main/java/com/io/linkapp/link/domain/Article.java
@@ -1,14 +1,12 @@
 package com.io.linkapp.link.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.io.linkapp.common.BaseTimeEntity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +28,7 @@ public class Article extends BaseTimeEntity {
     private String linkContent;
 
     @OneToMany(mappedBy = "article")
+    @JsonManagedReference
     private List<Memo> memos = new ArrayList<>();
 
     private boolean isPin;

--- a/src/main/java/com/io/linkapp/link/domain/Memo.java
+++ b/src/main/java/com/io/linkapp/link/domain/Memo.java
@@ -4,8 +4,11 @@ import com.io.linkapp.common.BaseTimeEntity;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,20 +24,26 @@ public class Memo extends BaseTimeEntity {
     @Column(name = "memo_id")
     private UUID id;
 
-    @Column(name = "article_id")
-    private UUID articleId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
 
     @Column(name = "memo_content")
     private String content;
 
     @Builder
-    public Memo(UUID id, UUID articleId, String content) {
+    public Memo(UUID id, Article article, String content) {
         this.id = id;
-        this.articleId = articleId;
+        this.article = article;
         this.content = content;
     }
 
     public void modify(String content){
         this.content = content;
+    }
+
+    public void addMemoToArticle(Article article) {
+        this.article = article;
+        article.getMemos().add(this);
     }
 }

--- a/src/main/java/com/io/linkapp/link/domain/Memo.java
+++ b/src/main/java/com/io/linkapp/link/domain/Memo.java
@@ -1,5 +1,6 @@
 package com.io.linkapp.link.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.io.linkapp.common.BaseTimeEntity;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -26,6 +27,7 @@ public class Memo extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
+    @JsonBackReference
     private Article article;
 
     @Column(name = "memo_content")
@@ -44,6 +46,8 @@ public class Memo extends BaseTimeEntity {
 
     public void addMemoToArticle(Article article) {
         this.article = article;
-        article.getMemos().add(this);
+        if(!article.getMemos().contains(this)) {
+            article.getMemos().add(this);
+        }
     }
 }

--- a/src/main/java/com/io/linkapp/link/mapper/ArticleMapper.java
+++ b/src/main/java/com/io/linkapp/link/mapper/ArticleMapper.java
@@ -1,0 +1,15 @@
+package com.io.linkapp.link.mapper;
+
+import com.io.linkapp.link.domain.Article;
+import com.io.linkapp.link.request.ArticleRequest;
+import com.io.linkapp.link.response.ArticleResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ArticleMapper {
+    ArticleMapper INSTANCE = Mappers.getMapper(ArticleMapper.class);
+
+    Article toEntity(ArticleRequest articleRequest);
+    ArticleResponse toResponseDto(Article article);
+}

--- a/src/main/java/com/io/linkapp/link/mapper/MemoMapper.java
+++ b/src/main/java/com/io/linkapp/link/mapper/MemoMapper.java
@@ -4,6 +4,7 @@ import com.io.linkapp.link.domain.Memo;
 import com.io.linkapp.link.request.MemoRequest;
 import com.io.linkapp.link.response.MemoResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper

--- a/src/main/java/com/io/linkapp/link/repository/ArticleRepository.java
+++ b/src/main/java/com/io/linkapp/link/repository/ArticleRepository.java
@@ -1,0 +1,9 @@
+package com.io.linkapp.link.repository;
+
+import com.io.linkapp.link.domain.Article;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, UUID> {
+
+}

--- a/src/main/java/com/io/linkapp/link/request/ArticleRequest.java
+++ b/src/main/java/com/io/linkapp/link/request/ArticleRequest.java
@@ -1,0 +1,28 @@
+package com.io.linkapp.link.request;
+
+import com.io.linkapp.common.BaseTimeEntity;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ArticleRequest extends BaseTimeEntity {
+
+    private UUID userId;
+    private UUID folderId;
+    private UUID remindId;
+
+    private String linkTitle;
+    private String linkContent;
+
+    @Builder
+    public ArticleRequest(UUID userId, UUID folderId, UUID remindId, String linkTitle,
+        String linkContent) {
+        this.userId = userId;
+        this.folderId = folderId;
+        this.remindId = remindId;
+        this.linkTitle = linkTitle;
+        this.linkContent = linkContent;
+    }
+
+}

--- a/src/main/java/com/io/linkapp/link/request/MemoRequest.java
+++ b/src/main/java/com/io/linkapp/link/request/MemoRequest.java
@@ -1,27 +1,18 @@
 package com.io.linkapp.link.request;
 
+import com.io.linkapp.link.domain.Article;
+import java.util.UUID;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
-
-import javax.validation.constraints.NotBlank;
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Getter
-@ToString
 public class MemoRequest {
-
-    private UUID id;
     private UUID articleId;
 
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
-    private LocalDateTime registerDate;
-    private LocalDateTime modifiedDate;
 
-
-    //TODO : @param articleId : Will delete After make article entity
     @Builder
     public MemoRequest(String content, UUID articleId) {
         this.content = content;

--- a/src/main/java/com/io/linkapp/link/response/ArticleResponse.java
+++ b/src/main/java/com/io/linkapp/link/response/ArticleResponse.java
@@ -1,0 +1,25 @@
+package com.io.linkapp.link.response;
+
+import com.io.linkapp.link.domain.Memo;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ArticleResponse {
+    private UUID id;
+    private UUID userId;
+    private UUID folderId;
+    private UUID remindId;
+    private String linkTitle;
+    private String linkContent;
+    private List<Memo> memos;
+    private boolean isPin;
+    private boolean isMemo;
+    private LocalDateTime registerDate;
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/io/linkapp/link/response/ArticleResponse.java
+++ b/src/main/java/com/io/linkapp/link/response/ArticleResponse.java
@@ -1,12 +1,12 @@
 package com.io.linkapp.link.response;
 
 import com.io.linkapp.link.domain.Memo;
-import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import lombok.Builder;
-import lombok.Getter;
 
 @Builder
 @Getter

--- a/src/main/java/com/io/linkapp/link/response/MemoResponse.java
+++ b/src/main/java/com/io/linkapp/link/response/MemoResponse.java
@@ -1,5 +1,6 @@
 package com.io.linkapp.link.response;
 
+import com.io.linkapp.link.domain.Article;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -8,16 +9,16 @@ import lombok.Getter;
 @Getter
 public class MemoResponse {
     private UUID id;
-    private UUID articleId;
+    private Article article;
     private String content;
     private LocalDateTime registerDate;
     private LocalDateTime modifiedDate;
 
     @Builder
-    public MemoResponse(UUID id, UUID articleId, String content, LocalDateTime registerDate,
+    public MemoResponse(UUID id, Article article, String content, LocalDateTime registerDate,
         LocalDateTime modifiedDate) {
         this.id = id;
-        this.articleId = articleId;
+        this.article = article;
         this.content = content;
         this.registerDate = registerDate;
         this.modifiedDate = modifiedDate;

--- a/src/main/java/com/io/linkapp/link/service/ArticleService.java
+++ b/src/main/java/com/io/linkapp/link/service/ArticleService.java
@@ -1,0 +1,44 @@
+package com.io.linkapp.link.service;
+
+import com.io.linkapp.exception.ArticleNotFoundException;
+import com.io.linkapp.link.domain.Article;
+import com.io.linkapp.link.mapper.ArticleMapper;
+import com.io.linkapp.link.repository.ArticleRepository;
+import com.io.linkapp.link.request.ArticleRequest;
+import com.io.linkapp.link.response.ArticleResponse;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleResponse findById(UUID id) {
+        Article article = articleRepository.findById(id)
+            .orElseThrow(ArticleNotFoundException::new);
+
+        return ArticleMapper.INSTANCE.toResponseDto(article);
+    }
+
+    public void add(ArticleRequest articleRequest){
+        articleRepository.save(ArticleMapper.INSTANCE.toEntity(articleRequest));
+ }
+
+    public List<ArticleResponse> getList(){
+        return articleRepository.findAll().stream().map(
+            article -> ArticleMapper.INSTANCE.toResponseDto(article)
+        ).collect(Collectors.toList());
+    }
+
+    public void remove(UUID uuid){
+        Article article = articleRepository.findById(uuid)
+            .orElseThrow(ArticleNotFoundException::new);
+
+        articleRepository.delete(article);
+    }
+}

--- a/src/test/java/com/io/linkapp/link/controller/api/ArticleApiTest.java
+++ b/src/test/java/com/io/linkapp/link/controller/api/ArticleApiTest.java
@@ -1,0 +1,130 @@
+package com.io.linkapp.link.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.io.linkapp.exception.ArticleNotFoundException;
+import com.io.linkapp.link.domain.Article;
+import com.io.linkapp.link.domain.Memo;
+import com.io.linkapp.link.mapper.ArticleMapper;
+import com.io.linkapp.link.repository.ArticleRepository;
+import com.io.linkapp.link.repository.MemoRepository;
+import com.io.linkapp.link.request.ArticleRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class ArticleApiTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    ArticleRepository articleRepository;
+
+    @Autowired
+    MemoRepository memoRepository;
+
+    private static ArticleRequest request;
+
+    @BeforeEach
+    void articleSetup(){
+        UUID uuid = UUID.randomUUID();
+
+       request = ArticleRequest.builder()
+                .folderId(uuid)
+                .remindId(uuid)
+                .userId(uuid)
+                .linkContent("getTest")
+                .linkTitle("getTest")
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST: /article 요청 시 링크가 저장된다")
+    void addTest() throws Exception {
+        //expected
+        mockMvc.perform(post("/article")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("GET: /article/{id}로 링크를 조회한다")
+    void getLink() throws Exception{
+        Article article = ArticleMapper.INSTANCE.toEntity(request);
+
+        articleRepository.save(article);
+
+        //expected
+        mockMvc.perform(get("/article/{id}", article.getId())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(article.getId().toString()))
+                .andExpect(jsonPath("$.linkContent").value("getTest"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("아티클 조회 시 아티클에 등록된 메모 모두 불러온다")
+    void getArticleMemoTest() throws Exception {
+        //given
+        Article article = ArticleMapper.INSTANCE.toEntity(request);
+
+        articleRepository.save(article);
+
+        Memo memo = Memo.builder()
+                .article(article)
+                .content("아티클에 등록된 메모 첫 번째")
+                .build();
+
+        Memo memo2 = Memo.builder()
+                .article(article)
+                .content("아티클에 등록된 메모 두 번째")
+                .build();
+
+        memoRepository.save(memo);
+        memoRepository.save(memo2);
+
+        //when
+        mockMvc.perform(get("/article/{id}", article.getId())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("DELETE: /article/{id} 요청 시 링크를 삭제한다")
+    void removeArticleTest() throws Exception {
+        //given
+        Article article = articleRepository.save(ArticleMapper.INSTANCE.toEntity(request));
+
+        //when
+        mockMvc.perform(delete("/article/{id}", article.getId()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        //then
+        Assertions.assertThrows(ArticleNotFoundException.class,
+                () -> articleRepository.findById(article.getId())
+                        .orElseThrow(ArticleNotFoundException::new));
+    }
+}

--- a/src/test/java/com/io/linkapp/link/controller/api/MemoApiTest.java
+++ b/src/test/java/com/io/linkapp/link/controller/api/MemoApiTest.java
@@ -1,12 +1,24 @@
 package com.io.linkapp.link.controller.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.io.linkapp.exception.MemoNotFoundException;
+import com.io.linkapp.link.domain.Article;
 import com.io.linkapp.link.domain.Memo;
+import com.io.linkapp.link.repository.ArticleRepository;
 import com.io.linkapp.link.repository.MemoRepository;
-import com.io.linkapp.link.service.MemoService;
 import com.io.linkapp.link.request.MemoRequest;
+import com.io.linkapp.link.service.MemoService;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,16 +26,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 class MemoApiTest {
 
     @Autowired
@@ -38,18 +45,34 @@ class MemoApiTest {
     @Autowired
     MemoRepository memoRepository;
 
+    @Autowired
+    ArticleRepository articleRepository;
+
+    private static Article article;
+
+    @BeforeEach
+    public void createArticle(){
+       article = Article.builder()
+            .folderId(UUID.randomUUID())
+            .remindId(UUID.randomUUID())
+            .linkTitle("링크제목")
+            .linkContent("링크내용")
+            .build();
+
+        articleRepository.save(article);
+    }
+
     @Test
-    @DisplayName("POST: api/memo 요청 시 메모가 저장된다.")
+    @DisplayName("POST: /memo 요청 시 메모가 저장된다.")
     void saveMemoTest() throws Exception {
         //given
-        UUID uuid = UUID.randomUUID();
         MemoRequest request = MemoRequest.builder()
-            .articleId(uuid)
+            .articleId(article.getId())
             .content("새로운 메모")
             .build();
 
         //expected
-        mockMvc.perform(post("/api/memo")
+        mockMvc.perform(post("/memo")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
@@ -60,59 +83,56 @@ class MemoApiTest {
     @DisplayName("POST: 단건 메모 저장 시 NULL, 공백이 들어가면 400에러를 반환한다")
     void saveNullMemo() throws Exception {
         //given
-        UUID uuid = UUID.randomUUID();
         MemoRequest request = MemoRequest.builder()
-                .articleId(uuid)
-                .content("")
-                .build();
+            .articleId(article.getId())
+            .content("")
+            .build();
 
         //expected
-        mockMvc.perform(post("/api/memo")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("내용을 입력해주세요."))
-                .andExpect(jsonPath("$.code").value(400))
-                .andDo(print());
+        mockMvc.perform(post("/memo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("내용을 입력해주세요."))
+            .andExpect(jsonPath("$.code").value(400))
+            .andDo(print());
     }
 
     @Test
     @DisplayName("POST: 단건 메모 저장 시 공백만 아주 많이 들어가도 400 에러를 반환한다")
     void saveNullRecursiveMemo() throws Exception {
         //given
-        UUID uuid = UUID.randomUUID();
         MemoRequest request = MemoRequest.builder()
-                .articleId(uuid)
-                .content("                  ")
-                .build();
+            .articleId(article.getId())
+            .content("               ")
+            .build();
 
         //expected
-        mockMvc.perform(post("/api/memo")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("내용을 입력해주세요."))
-                .andExpect(jsonPath("$.code").value(400))
-                .andDo(print());
+        mockMvc.perform(post("/memo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("내용을 입력해주세요."))
+            .andExpect(jsonPath("$.code").value(400))
+            .andDo(print());
     }
 
     @Test
-    @DisplayName("GET: api/memo/{id} 요청 시 해당 메모를 불러온다")
+    @DisplayName("GET: /memo/{id} 요청 시 해당 메모를 불러온다")
     void findMemoById() throws Exception {
         //given
-        UUID uuid = UUID.randomUUID();
         Memo request = Memo.builder()
-            .articleId(uuid)
+            .article(article)
             .content("새로운 메모")
             .build();
 
         memoRepository.save(request);
 
         //expected
-        mockMvc.perform(get("/api/memo/{id}", request.getId())
+        mockMvc.perform(get("/memo/{id}", request.getId())
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.id").value(request.getId().toString()))
-            .andExpect(jsonPath("$.articleId").value(uuid.toString()))
+            .andExpect(jsonPath("$.article.id").value(article.getId().toString()))
             .andExpect(jsonPath("$.content").value("새로운 메모"))
             .andDo(print());
     }
@@ -121,37 +141,35 @@ class MemoApiTest {
     @DisplayName("GET: 없는 메모를 조회 시 404 에러를 반환한다")
     void findNotExistedMemo() throws Exception {
         //expected
-        mockMvc.perform(get("/api/memo/{id}", UUID.randomUUID())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 메모입니다."))
-                .andDo(print());
+        mockMvc.perform(get("/memo/{id}", UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("존재하지 않는 메모입니다."))
+            .andDo(print());
     }
 
     @Test
-    @DisplayName("PATCH: api/memo/{id} 로 메모 내용을 변경한다.")
+    @DisplayName("PATCH: /memo/{id} 로 메모 내용을 변경한다.")
     void editMemo() throws Exception {
-
         //given
-        UUID uuid = UUID.randomUUID();
         Memo memo = Memo.builder()
-                .articleId(uuid)
-                .content("메모")
-                .build();
+            .article(article)
+            .content("메모")
+            .build();
 
         memoRepository.save(memo);
 
         MemoRequest memoRequest = MemoRequest.builder()
-                .content("메모수정")
-                .build();
+            .content("메모수정")
+            .build();
 
         //when
-        mockMvc.perform(patch("/api/memo/{id}", memo.getId())
+        mockMvc.perform(patch("/memo/{id}", memo.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memoRequest)))
-                .andExpect(status().isOk())
-                .andDo(print());
+                .content(objectMapper.writeValueAsString(memoRequest)))
+            .andExpect(status().isOk())
+            .andDo(print());
 
         //then
         String content = memoRepository.findById(memo.getId()).get().getContent();
@@ -159,37 +177,36 @@ class MemoApiTest {
     }
 
     @Test
-    @DisplayName("DELETE: api/memo/{id} 메모 삭제 시 정상적으로 삭제 된다")
+    @DisplayName("DELETE: /memo/{id} 메모 삭제 시 정상적으로 삭제 된다")
     void deleteMemo() throws Exception {
         //given
-        UUID uuid = UUID.randomUUID();
         Memo temporaryMemo = Memo.builder()
-                .articleId(uuid)
-                .content("임시메모")
-                .build();
+                .article(article)
+            .content("임시메모")
+            .build();
 
         memoRepository.save(temporaryMemo);
 
         //when
         UUID memoId = temporaryMemo.getId();
-        mockMvc.perform(delete("/api/memo/{id}", memoId)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
+        mockMvc.perform(delete("/memo/{id}", memoId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(print());
 
         //then
         Assertions.assertThrows(MemoNotFoundException.class,
-                () -> memoService.findById(memoId));
+            () -> memoService.findById(memoId));
     }
-    
+
     @Test
-    @DisplayName("DELETE: api/memo/{id} 없는 메모를 삭제 시 404를 반환한다")
+    @DisplayName("DELETE: /memo/{id} 없는 메모를 삭제 시 404를 반환한다")
     void deleteNotExistMemo() throws Exception {
-        mockMvc.perform(delete("/api/memo/{id}", UUID.randomUUID())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 메모입니다."))
-                .andDo(print());
+        mockMvc.perform(delete("/memo/{id}", UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(404))
+            .andExpect(jsonPath("$.message").value("존재하지 않는 메모입니다."))
+            .andDo(print());
     }
 }


### PR DESCRIPTION
* 아티클 API CRUD입니다.
* 수정 API의 경우 Link Content와 Link Titlte 의 차이점이 명확하게 나온 이후 작업이 가능할 것 같습니다.
* 컨트롤러 단의 통합테스트를 진행하였습니다.
* 특이사항으로 연관관계 상(Memo - Article)에서 조회 API 호출 시 JSON 순환 참조가 발생합니다. @JsonReference 어노테이션 추가로 정상 작동하고 있으나 이 부분은 김영한 JPA활용 2편에 상세한 레퍼런스가 있다고 해서 강의 들어보고 고쳐보겠습니당.